### PR TITLE
AtCoderDifficultyDisplayとの衝突を回避するようにした

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,14 +2,14 @@ window.onload = function () {
     var allTags = document.getElementsByTagName('p');
     for (var tag of allTags) {
         if (tag.textContent.match(/実行時間制限/)) {
-            if (tag.textContent != '実行時間制限: 2 sec / メモリ制限: 1024 MB') {
+            if (!tag.textContent.startsWith('実行時間制限: 2 sec / メモリ制限: 1024 MB')) {
                 tag.style.color = "red"
                 tag.style.fontSize = "xx-large"
                 break;
             }
         }
         if (tag.textContent.match(/Time Limit*/)) {
-            if (tag.textContent != 'Time Limit: 2 sec / Memory Limit: 1024 MB') {
+            if (!tag.textContent.startsWith('Time Limit: 2 sec / Memory Limit: 1024 MB')) {
                 tag.style.color = "red"
                 tag.style.fontSize = "xx-large"
                 break;


### PR DESCRIPTION
<img width="1045" alt="Screen Shot 0002-06-28 at 10 58 50" src="https://user-images.githubusercontent.com/728375/85935769-37dc3000-b92f-11ea-862b-f8cc27ec4bd7.png">

AtCoderDifficultyDisplayというユーザスクリプトで同じタグの中を修正していて、結果として誤検出になってしまう場合があったので、完全一致ではなく先頭一致に修正してみました。